### PR TITLE
Make DMeshEditor get Newtonsoft.Json from NuGet (like OLE)

### DIFF
--- a/Editor/DMeshEditor/DMeshEditor/DMeshEditor.csproj
+++ b/Editor/DMeshEditor/DMeshEditor/DMeshEditor.csproj
@@ -53,8 +53,9 @@
       <HintPath>..\..\..\3rdParty\CjClutter.ObjLoader.Loader.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\3rdParty\JSON.NET\Net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK">
       <HintPath>..\..\..\3rdParty\OpenTK.dll</HintPath>
@@ -204,6 +205,7 @@
       <DependentUpon>TextureList.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="ClassDiagram1.cd" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/Editor/DMeshEditor/DMeshEditor/packages.config
+++ b/Editor/DMeshEditor/DMeshEditor/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net40-client" />
+</packages>


### PR DESCRIPTION
Needed to make a small change so the DMesh editor would build on a fresh clone.