### PR TITLE
Add Visible check to UVEditor_LocationChanged

### DIFF
--- a/OverloadLevelEditor/Popups/UVEditor.cs
+++ b/OverloadLevelEditor/Popups/UVEditor.cs
@@ -308,7 +308,10 @@ namespace OverloadLevelEditor
 
 		private void UVEditor_LocationChanged(object sender, EventArgs e)
 		{
-			editor.m_uv_editor_loc = this.Location;
+			if (Visible)
+			{
+				editor.m_uv_editor_loc = this.Location;
+			}
 		}
 
 		private void UVEditor_Shown(object sender, EventArgs e)


### PR DESCRIPTION
This fixes #24 

Investigated why the UV editor's position always resets on restart - this was apparently why. The location change event when the window is created clobbers the saved position restored from preferences. Other floating dialogs appear to work around the issue by only re-saving the position when the window is visible.