### PR TITLE
Fix export with portal with lava slave side

### DIFF
--- a/OverloadLevelEditor/Export/SceneBroker.cs
+++ b/OverloadLevelEditor/Export/SceneBroker.cs
@@ -233,7 +233,8 @@ namespace OverloadLevelExport
 					if (!meshColliderComponent.TryGetPropertyDuringExport<bool>("isTrigger", out isTrigger) || isTrigger == false) {
 						// Not a trigger, get the mesh
 						UnityEngine.Mesh mesh;
-						if (meshColliderComponent.TryGetPropertyDuringExport<UnityEngine.Mesh>("sharedMesh", out mesh)) {
+						if (meshColliderComponent.TryGetPropertyDuringExport<UnityEngine.Mesh>("sharedMesh", out mesh) &&
+							mesh.vertices.Length != 0) {
 							collisionList.Add(new Tuple<int, UnityEngine.Mesh>(go.Layer, mesh));
 							var meshMin = mesh.bounds.min;
 							var meshMax = mesh.bounds.max;


### PR DESCRIPTION
When a portal has a lava texture on the side with the highest segment
number (the slave side) and there are no other lava textures,
the lava texture is ignored but there is a lava collision mesh
created which will be empty. This causes a crash when the empty mesh
is added to the EditorPhysics collision engine.
This commit makes it ignore the empty mesh.

Resolves: #27