### PR TITLE
Improve Obj import

### DIFF
--- a/Editor/Common/ImportOBJ.cs
+++ b/Editor/Common/ImportOBJ.cs
@@ -1,0 +1,182 @@
+/*
+THE COMPUTER CODE CONTAINED HEREIN IS THE SOLE PROPERTY OF REVIVAL
+PRODUCTIONS, LLC ("REVIVAL").  REVIVAL, IN DISTRIBUTING THE CODE TO
+END-USERS, AND SUBJECT TO ALL OF THE TERMS AND CONDITIONS HEREIN, GRANTS A
+ROYALTY-FREE, PERPETUAL LICENSE TO SUCH END-USERS FOR USE BY SUCH END-USERS
+IN USING, DISPLAYING,  AND CREATING DERIVATIVE WORKS THEREOF, SO LONG AS
+SUCH USE, DISPLAY OR CREATION IS FOR NON-COMMERCIAL, ROYALTY OR REVENUE
+FREE PURPOSES.  IN NO EVENT SHALL THE END-USER USE THE COMPUTER CODE
+CONTAINED HEREIN FOR REVENUE-BEARING PURPOSES.  THE END-USER UNDERSTANDS
+AND AGREES TO THE TERMS HEREIN AND ACCEPTS THE SAME BY USE OF THIS FILE.
+COPYRIGHT 2015-2020 REVIVAL PRODUCTIONS, LLC.  ALL RIGHTS RESERVED.
+*/
+
+using System.IO;
+using ObjLoader.Loader.Loaders;
+using OpenTK;
+
+namespace OverloadLevelEditor
+{
+	public static class ImportOBJ {
+		public static bool CopyImportTextureToDecalFolder(string name, string filepath_decal_textures)
+		{
+			string dest_file = Path.Combine( filepath_decal_textures, name );
+			string src_file = Path.Combine( Directory.GetCurrentDirectory(), name );
+			if (dest_file == src_file) {
+				// No need to do anything
+				return false;
+			}
+
+			if( !File.Exists( src_file ) ) {
+				Utility.DebugPopup( string.Format( "The file \"{0}\" does not exist", src_file ) );
+				return false;
+			}
+
+			try {
+				if( File.Exists( dest_file ) ) {
+					File.Delete( dest_file );
+				}
+				File.Copy( src_file, dest_file );
+				return true;
+			} catch {
+				Utility.DebugLog( "Tried to import to a texture that is currently in use" );
+				return false;
+			}
+		}
+
+		public static void ConvertLoadResultToDMesh(LoadResult load_result, DMesh dm, bool units_inches, Editor editor, TextureManager tex_manager)
+		{
+			// Convert the verts
+			ObjLoader.Loader.Data.VertexData.Vertex v;
+			for (int i = 0; i < load_result.Vertices.Count; i++) {
+				v = load_result.Vertices[i];
+				#if DMESH_EDITOR
+				dm.AddVertexEditor(new Vector3(v.X, v.Y, v.Z), false);
+				#else
+				dm.AddVertex(v.X, v.Y, v.Z);
+				#endif
+			}
+
+			if (units_inches) {
+				for (int i = 0; i < dm.vertex.Count; i++) {
+					dm.vertex[i] *= 0.0254f;
+				}
+			}
+
+			// Rotate all the verts 180
+			dm.RotateMesh180();
+
+			// Convert the faces
+			int[] vrt_idx = new int[3];
+			Vector3[] nrml = new Vector3[3];
+			Vector2[] uv = new Vector2[3];
+			string tex_name;
+
+			int tex_idx = 0;
+
+			ObjLoader.Loader.Data.VertexData.Normal n;
+			ObjLoader.Loader.Data.VertexData.Texture t;
+			ObjLoader.Loader.Data.Elements.FaceVertex fv;
+
+			foreach (ObjLoader.Loader.Data.Elements.Group g in load_result.Groups) {
+				tex_name = g.Material.DiffuseTextureMap;
+				if (!CopyImportTextureToDecalFolder(tex_name, editor.m_filepath_decal_textures)) {
+					Utility.DebugLog("No texture imported/updated: " + tex_name);
+				} else {
+					Utility.DebugLog("Imported/updated a texture: " + tex_name);
+				}
+
+				string tex_id_name = Path.ChangeExtension(tex_name, null);
+				if (tex_manager.FindTextureIDByName(tex_id_name) < 0) {
+					// Get the texture (if it exists)
+					if (File.Exists(tex_id_name + ".png")) {
+						tex_manager.LoadTexture(tex_id_name + ".png", true);
+					} else {
+						// Try to steal it from the level directory instead
+						string level_tex_name = editor.m_filepath_level_textures + "\\" + tex_id_name + ".png";
+						if (File.Exists(level_tex_name)) {
+							// Copy it to the decal textures directory, then load it
+							string decal_tex_name = editor.m_filepath_decal_textures + "\\" + tex_id_name + ".png";
+							if (!File.Exists(decal_tex_name)) {
+								File.Copy(level_tex_name, decal_tex_name);
+
+								tex_manager.LoadTexture(decal_tex_name, true);
+							}
+						} else {
+							Utility.DebugPopup("No PNG file could be found matching the name: " + tex_id_name, "IMPORT WARNING!");
+						}
+					}
+				}
+
+				dm.AddTexture(tex_idx, tex_id_name);
+				foreach (ObjLoader.Loader.Data.Elements.Face f in g.Faces) {
+					// Only works for 3 vert faces (currently)
+					for (int i = 0; i < f.Count; i++) {
+						if (i < 3) {
+							fv = f[i];
+							vrt_idx[i] = fv.VertexIndex - 1;
+							n = load_result.Normals[fv.NormalIndex - 1];
+							t = load_result.Textures[fv.TextureIndex - 1];
+							nrml[i] = new Vector3(n.X, n.Y, n.Z);
+
+							// Since we use OpenGL for rendering, but don't load
+							// the texture images in upside down (as OpenGL expects)
+							// we must flip the V coordinate of the UVs so that decals
+							// render correctly.
+							//
+							// What I don't understand is why the U coordinates of geometry
+							// decals need to be flipped also. I wonder if this is the
+							// in the WaveFront OBJ specification or something else.
+							// uv[i] = new Vector2(1.0f - t.X, 1.0f - t.Y);
+										uv[i] = new Vector2(t.X, 1f - t.Y);
+						}
+					}
+
+					dm.AddFace(vrt_idx, nrml, uv, tex_idx);
+				}
+
+				tex_idx += 1;
+			}
+		}
+
+		public static bool ImportOBJToDMesh(DMesh dm, string obj_file_name, bool units_inches, Editor editor, TextureManager tex_manager)
+		{
+			if( !Path.IsPathRooted(obj_file_name) ) {
+				// Make sure the file path is absolute
+				obj_file_name = Path.GetFullPath(obj_file_name);
+			}
+
+			if( !File.Exists( obj_file_name ) ) {
+				return false;
+			}
+
+			string obj_working_dir = Path.GetDirectoryName(obj_file_name);
+
+			string current_working_directory = Directory.GetCurrentDirectory();
+			try {
+				LoadResult load_result;
+				ObjLoaderFactory obj_loader_factory = new ObjLoaderFactory();
+				IObjLoader obj_loader = obj_loader_factory.Create();
+
+				// Have to set working directory so loading of the material file will work
+				Directory.SetCurrentDirectory(obj_working_dir);
+				using (FileStream file_stream = new FileStream(obj_file_name, FileMode.Open, FileAccess.Read)) {
+					load_result = obj_loader.Load(file_stream);
+					file_stream.Close();
+				}
+
+				ConvertLoadResultToDMesh(load_result, dm, units_inches, editor, tex_manager);
+				//m_active_dmesh.CenterMesh();
+				dm.FlipMesh(-1f, 1f);
+				dm.FlipVertNormalsZ();
+				//active_dmesh.RotateMesh90();
+			}
+			finally {
+				// Restore the working directory
+				Directory.SetCurrentDirectory( current_working_directory );
+			}
+
+			return true;
+		}
+	}
+}

--- a/Editor/Common/ObjFile.cs
+++ b/Editor/Common/ObjFile.cs
@@ -1,0 +1,248 @@
+using OpenTK;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace ObjFileLib
+{
+	public class ObjFile
+	{
+		public struct FaceVert
+		{
+			public int VertIdx;
+			public int UVIdx;
+			public int NormIdx;
+			public FaceVert(int vertIdx, int uvIdx, int normIdx)
+			{
+				VertIdx = vertIdx;
+				UVIdx = uvIdx;
+				NormIdx = normIdx;
+			}
+		}
+
+		public struct Face
+		{
+			public FaceVert[] FaceVerts;
+			public int MatIdx;
+
+			public Face(FaceVert[] faceVerts, int matIdx)
+			{
+				FaceVerts = faceVerts;
+				MatIdx = matIdx;
+			}
+		}
+
+		public struct MaterialChannel
+		{
+			public Color Color;
+			public string Texture;
+		}
+
+		public class Material
+		{
+			public string Name;
+			public MaterialChannel Diffuse;
+		}
+
+		public List<Vector3> Vertices = new List<Vector3>();
+		public List<Vector3> Normals = new List<Vector3>();
+		public List<Vector2> UVs = new List<Vector2>();
+		public List<Face> Faces = new List<Face>();
+		public List<Material> Materials = new List<Material>();
+
+		private static float ToFloat(string s)
+		{
+			return float.Parse(s, CultureInfo.InvariantCulture);
+		}
+
+		private static int ToIdx(string s, int count)
+		{
+			var n = s == "" ? 0 : int.Parse(s, CultureInfo.InvariantCulture);
+			return n < 0 ? n + count : n - 1;
+		}
+
+		private int NextNonWhiteSpaceIdx(string s, int i)
+		{
+			while (i < s.Length && Char.IsWhiteSpace(s[i]))
+				i++;
+			return i;
+		}
+
+		private int NextWhiteSpaceIdx(string s, int i)
+		{
+			while (i < s.Length && !Char.IsWhiteSpace(s[i]))
+				i++;
+			return i;
+		}
+
+		private bool SplitLine(string line, out string keyword, out string arg)
+		{
+			var i = NextNonWhiteSpaceIdx(line, 0);
+			if (i == line.Length || line[i] == '#') {
+				keyword = arg = null;
+				return false;
+			}
+			var j = NextWhiteSpaceIdx(line, i);
+			keyword = line.Substring(i, j - i);
+			i = NextNonWhiteSpaceIdx(line, j);
+			arg = line.Substring(i).TrimEnd();
+			return true;
+		}
+
+		private Dictionary<string, Material> LoadMtl(string filename)
+		{
+			Material cur = null;
+			var materials = new Dictionary<string, Material>();
+			foreach (var line in File.ReadLines(filename))
+			{
+				string keyword, arg;
+				if (!SplitLine(line, out keyword, out arg))
+					continue;
+				switch (keyword)
+				{
+					case "newmtl":
+						cur = new Material();
+						cur.Name = arg;
+						materials[cur.Name] = cur;
+						break;
+					case "map_Kd":
+						if (cur != null)
+							cur.Diffuse.Texture = arg;
+						break;
+					case "Kd":
+						if (cur != null) {
+							var parts = arg.Split((string[])null, StringSplitOptions.RemoveEmptyEntries);
+							cur.Diffuse.Color = Color.FromArgb((int)(ToFloat(parts[0]) * 255), (int)(ToFloat(parts[1]) * 255), (int)(ToFloat(parts[2]) * 255));
+						}
+						break;
+				}
+			}
+			return materials;
+		}
+
+		public void Load(string filename)
+		{
+			var sepSlash = new char[] { '/' };
+			var mtlIdx = new Dictionary<string, int>();
+			int curMtl = 0;
+			var materials = new Dictionary<string, Material>();
+
+			foreach (var line in File.ReadLines(filename))
+			{
+				string keyword, arg;
+				if (!SplitLine(line, out keyword, out arg))
+					continue;
+				var parts = arg.Split((string[])null, StringSplitOptions.RemoveEmptyEntries);
+				switch (keyword)
+				{
+					case "mtllib":
+						var mtlFile = Path.Combine(Path.GetDirectoryName(filename), arg);
+						if (File.Exists(mtlFile))
+							materials = LoadMtl(mtlFile);
+						break;
+					case "usemtl":
+						string mtl = arg;
+						Material m;
+						if (!mtlIdx.TryGetValue(mtl, out curMtl) &&
+							materials.TryGetValue(mtl, out m)) {
+							curMtl = Materials.Count;
+							mtlIdx.Add(mtl, curMtl);
+							Materials.Add(m);
+						}
+						break;
+					case "v":
+						Vertices.Add(new Vector3(ToFloat(parts[0]), ToFloat(parts[1]), ToFloat(parts[2])));
+						break;
+					case "vn":
+						Normals.Add(new Vector3(ToFloat(parts[0]), ToFloat(parts[1]), ToFloat(parts[2])));
+						break;
+					case "vt":
+						UVs.Add(new Vector2(ToFloat(parts[0]), ToFloat(parts[1])));
+						break;
+					case "f":
+						Faces.Add(new Face(parts.Select(x => {
+								var ns = x.Split(sepSlash);
+								return new FaceVert(ToIdx(ns[0], Vertices.Count), ToIdx(ns[1], UVs.Count), ToIdx(ns[2], Normals.Count));
+							}).ToArray(), curMtl));
+						break;
+					case "s":
+					case "g":
+					case "o":
+					case "l":
+						break;
+					default:
+						throw new Exception("Unknown line " + line);
+				}
+			}
+		}
+	}
+
+	public class TGAFile
+	{
+		public static Bitmap Read(BinaryReader r)
+		{
+			byte image_id_len = r.ReadByte();
+			byte color_map_type = r.ReadByte();
+			byte image_type = r.ReadByte();
+
+			if (color_map_type != 0 || image_type != 10)
+				return null;
+
+			// color map spec + x / y origin
+			for (int i = 0; i < 9; i++)
+				r.ReadByte();
+
+			int width = r.ReadInt16();
+			int height = r.ReadInt16();
+			int pixdepth = r.ReadByte();
+
+			if (pixdepth != 24)
+				return null;
+
+			int descriptor = r.ReadByte();
+			if (descriptor != 0)
+				return null;
+
+			for (int i = 0; i < image_id_len; i++)
+				r.ReadByte();
+
+			int[] img = new int[width * height];
+
+			int total = width * height, idx = 0;
+			if (image_type == 10) {
+				while (idx < total) {
+					int cmd = r.ReadByte();
+					if ((cmd & 0x80) != 0) {
+						int pixel = r.ReadUInt16() | unchecked((int)0xff000000);
+						pixel |= r.ReadByte() << 16;
+						int n = (cmd & 0x7f) + 1;
+						while (n-- != 0)
+							img[idx++] = pixel;
+					} else {
+						int n = cmd + 1;
+						while (n-- != 0) {
+							int pixel = r.ReadUInt16() | unchecked((int)0xff000000);
+							pixel |= r.ReadByte() << 16;
+							img[idx++] = pixel;
+						}
+					}
+				}
+			} else
+				throw new Exception("Invalid image file type");
+
+			Rectangle rect = new Rectangle(0, 0, width, height);
+			PixelFormat fmt = PixelFormat.Format32bppArgb;
+			Bitmap bmp = new Bitmap(width, height, fmt);
+			BitmapData d = bmp.LockBits(rect, ImageLockMode.ReadWrite, fmt);
+			for (int p = 0; p < total; p += width)
+				Marshal.Copy(img, total - p - width, d.Scan0 + p * 4, width);
+			bmp.UnlockBits(d);
+			return bmp;
+		}
+	}
+}

--- a/Editor/DMeshEditor/DMeshEditor/DMeshEditor.csproj
+++ b/Editor/DMeshEditor/DMeshEditor/DMeshEditor.csproj
@@ -51,12 +51,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <PlatformTarget>x64</PlatformTarget>
     <OutputPath>bin\x64\Debug\</OutputPath>
-	<DefineConstants>TRACE;DEBUG;OVERLOAD_LEVEL_EDITOR</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;OVERLOAD_LEVEL_EDITOR,DMESH_EDITOR</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
     <OutputPath>bin\x64\Release\</OutputPath>
-	<DefineConstants>TRACE;DEBUG;OVERLOAD_LEVEL_EDITOR</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;OVERLOAD_LEVEL_EDITOR,DMESH_EDITOR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CjClutter.ObjLoader.Loader">
@@ -100,6 +100,9 @@
     </Compile>
     <Compile Include="..\..\Common\HSBColor.cs">
       <Link>Utility\HSBColor.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\ImportOBJ.cs">
+      <Link>Utility\ImportOBJ.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\UnityStub.cs">
       <Link>Utility\UnityStub.cs</Link>

--- a/Editor/DMeshEditor/DMeshEditor/DMeshEditor.csproj
+++ b/Editor/DMeshEditor/DMeshEditor/DMeshEditor.csproj
@@ -104,6 +104,9 @@
     <Compile Include="..\..\Common\ImportOBJ.cs">
       <Link>Utility\ImportOBJ.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\ObjFile.cs">
+      <Link>Utility\ObjFile.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\UnityStub.cs">
       <Link>Utility\UnityStub.cs</Link>
     </Compile>

--- a/Editor/DMeshEditor/DMeshEditor/Main/Editor.Designer.cs
+++ b/Editor/DMeshEditor/DMeshEditor/Main/Editor.Designer.cs
@@ -129,7 +129,6 @@ namespace OverloadLevelEditor
 			this.button_flip_v = new System.Windows.Forms.Button();
 			this.button_edge_bottom = new System.Windows.Forms.Button();
 			this.button_edge_top = new System.Windows.Forms.Button();
-			this.button_import_replace = new System.Windows.Forms.Button();
 			this.button_import = new System.Windows.Forms.Button();
 			this.button_planarize = new System.Windows.Forms.Button();
 			this.button_create_quad = new System.Windows.Forms.Button();
@@ -1212,17 +1211,6 @@ namespace OverloadLevelEditor
 			this.button_edge_top.UseVisualStyleBackColor = true;
 			this.button_edge_top.Click += new System.EventHandler(this.button_edge_top_Click);
 			// 
-			// button_import_replace
-			// 
-			this.button_import_replace.Location = new System.Drawing.Point(3, 150);
-			this.button_import_replace.Margin = new System.Windows.Forms.Padding(1);
-			this.button_import_replace.Name = "button_import_replace";
-			this.button_import_replace.Size = new System.Drawing.Size(143, 21);
-			this.button_import_replace.TabIndex = 95;
-			this.button_import_replace.Text = "Import OBJ - Replace";
-			this.tool_tip.SetToolTip(this.button_import_replace, "Import an OBJ file to replace the current decal geometry");
-			this.button_import_replace.UseVisualStyleBackColor = true;
-			// 
 			// button_import
 			// 
 			this.button_import.Location = new System.Drawing.Point(3, 127);
@@ -1230,9 +1218,10 @@ namespace OverloadLevelEditor
 			this.button_import.Name = "button_import";
 			this.button_import.Size = new System.Drawing.Size(143, 21);
 			this.button_import.TabIndex = 94;
-			this.button_import.Text = "Import OBJ - New";
+			this.button_import.Text = "Import OBJ";
 			this.tool_tip.SetToolTip(this.button_import, "Import an OBJ file as a new decal");
 			this.button_import.UseVisualStyleBackColor = true;
+			this.button_import.Click += new System.EventHandler(this.button_import_Click);
 			// 
 			// button_planarize
 			// 
@@ -2478,7 +2467,6 @@ namespace OverloadLevelEditor
 			this.Controls.Add(this.label_scalemode);
 			this.Controls.Add(this.label_pivotmode);
 			this.Controls.Add(this.button_planarize);
-			this.Controls.Add(this.button_import_replace);
 			this.Controls.Add(this.button_import);
 			this.Controls.Add(this.panel3);
 			this.Controls.Add(this.slider_coplanar_angle);
@@ -2585,7 +2573,6 @@ namespace OverloadLevelEditor
 		  private System.Windows.Forms.Button button_flip_v;
 		  private System.Windows.Forms.Button button_edge_bottom;
 		  private System.Windows.Forms.Button button_edge_top;
-		  private System.Windows.Forms.Button button_import_replace;
 		  private System.Windows.Forms.Button button_import;
 		  private System.Windows.Forms.Button button_planarize;
 		  private System.Windows.Forms.Label label_pivotmode;

--- a/Editor/DMeshEditor/DMeshEditor/Main/Editor.cs
+++ b/Editor/DMeshEditor/DMeshEditor/Main/Editor.cs
@@ -1311,5 +1311,35 @@ namespace OverloadLevelEditor
 			auto_copy_face_flags = !auto_copy_face_flags;
 			autoCopyFaceFlagsToMarkedToolStripMenuItem.Checked = auto_copy_face_flags;
 		}
+
+		private void button_import_Click(object sender, EventArgs e)
+		{
+			if (m_dmesh.dirty) {
+				DialogResult dr = MessageBox.Show("DMesh has changed.  Save it before importing OBJ file?", "Save DMesh?", MessageBoxButtons.YesNoCancel);
+				if (dr == DialogResult.Yes) {
+					saveToolStripMenuItem_Click(this, e);
+				} else if (dr == DialogResult.Cancel) {
+					// Nevermind!
+					return;
+				}
+			}
+
+			using (OpenFileDialog od = new OpenFileDialog()) {
+				od.AddExtension = true;
+				od.CheckFileExists = true;
+				od.CheckPathExists = true;
+				od.DefaultExt = ".obj";
+				od.Filter = "OBJ mesh files (*.obj) | *.obj";
+				od.Multiselect = false;
+				od.Title = "Import an OBJ mesh file";
+
+				var res = od.ShowDialog();
+				if (res != DialogResult.OK)
+					return;
+				ImportOBJ(m_dmesh, od.FileName);
+
+				RefreshGeometry();
+			}
+		}
 	}
 }

--- a/Editor/DMeshEditor/DMeshEditor/Main/EditorUtility.cs
+++ b/Editor/DMeshEditor/DMeshEditor/Main/EditorUtility.cs
@@ -988,5 +988,30 @@ namespace OverloadLevelEditor
 
 			InitColors();
 		}
+
+		public bool ImportOBJ(DMesh dm, string path_to_file)
+		{
+			dm.Init(this);
+			try {
+				if (!OverloadLevelEditor.ImportOBJ.ImportOBJToDMesh(dm, path_to_file, false, this, tm_decal))
+                    return false;
+
+				dm.UpdateGLTextures(tm_decal);
+
+				dm.dirty = true;
+
+				if (!dm.WasConverted()) {
+					m_dmesh.ConvertTrisToPolysRaw();
+					dm.dirty = true;
+				}
+				UpdateOptionLabels();
+
+				return true;
+			}
+			catch (Exception ex) {
+				Utility.DebugLog("Failed to load OBJ: " + ex.Message);
+				return false;
+			}
+		}
 	}
 }

--- a/Editor/DMeshEditor/DMeshEditor/Main/EditorUtility.cs
+++ b/Editor/DMeshEditor/DMeshEditor/Main/EditorUtility.cs
@@ -998,7 +998,7 @@ namespace OverloadLevelEditor
 
 				dm.UpdateGLTextures(tm_decal);
 
-				dm.dirty = true;
+				dm.dirty = false;
 
 				if (!dm.WasConverted()) {
 					m_dmesh.ConvertTrisToPolysRaw();
@@ -1009,7 +1009,7 @@ namespace OverloadLevelEditor
 				return true;
 			}
 			catch (Exception ex) {
-				Utility.DebugLog("Failed to load OBJ: " + ex.Message);
+				Utility.DebugPopup("Failed to load OBJ: " + ex.Message, "Error");
 				return false;
 			}
 		}

--- a/Editor/DMeshEditor/DMeshEditor/Main/TextureManager.cs
+++ b/Editor/DMeshEditor/DMeshEditor/Main/TextureManager.cs
@@ -81,6 +81,8 @@ namespace OverloadLevelEditor
 
 		private Bitmap ResizeBitmap(Bitmap source_bmp, int width, int height)
 		{
+			if (source_bmp.Width < width && source_bmp.Height < height)
+				return (Bitmap)source_bmp.Clone();
 			Bitmap result = new Bitmap(width, height);
 			using (Graphics g = Graphics.FromImage(result))
 				g.DrawImage(source_bmp, 0, 0, width, height);
@@ -117,6 +119,18 @@ namespace OverloadLevelEditor
 		{
 			Bitmap bmp = new Bitmap(bmp_name);
 			return LoadTexture(bmp, dispose_bmp); // NOTE(Jeff): shouldn't this always dispose this bmp?
+		}
+
+		public int AddTexture(string bmp_name)
+		{
+			Bitmap bmp = new Bitmap(bmp_name);
+			var small_bmp = ResizeBitmap(bmp, 128, 128);
+			int gl_id = LoadTexture(bmp, true);
+
+			m_name.Add(Path.GetFileNameWithoutExtension(bmp_name));
+			m_bitmap.Add(small_bmp);
+			m_gl_id.Add(gl_id);
+			return gl_id;
 		}
 
 		public int FindTextureIDByName(string tex_name)

--- a/OverloadLevelEditor/Main/TextureManager.cs
+++ b/OverloadLevelEditor/Main/TextureManager.cs
@@ -106,6 +106,18 @@ namespace OverloadLevelEditor
 			return LoadTexture(bmp, dispose_bmp); // NOTE(Jeff): shouldn't this always dispose this bmp?
 		}
 
+		public int AddTexture(string bmp_name)
+		{
+			Bitmap bmp = new Bitmap(bmp_name);
+			var small_bmp = ResizeBitmap(bmp, 128, 128);
+			int gl_id = LoadTexture(bmp, true);
+
+			m_name.Add(Path.GetFileNameWithoutExtension(bmp_name));
+			m_bitmap.Add(small_bmp);
+			m_gl_id.Add(gl_id);
+			return gl_id;
+		}
+
 		public int FindTextureIndexByName(string tex_name)
 		{
 			if (tex_name == "") {

--- a/OverloadLevelEditor/OverloadLevelEditor.csproj
+++ b/OverloadLevelEditor/OverloadLevelEditor.csproj
@@ -254,6 +254,9 @@
     <Compile Include="..\Editor\Common\HSBColor.cs">
       <Link>Utility\HSBColor.cs</Link>
     </Compile>
+    <Compile Include="..\Editor\Common\ImportOBJ.cs">
+      <Link>Utility\ImportOBJ.cs</Link>
+    </Compile>
     <Compile Include="..\Editor\Common\UnityStub.cs">
       <Link>Utility\UnityStub.cs</Link>
     </Compile>

--- a/OverloadLevelEditor/OverloadLevelEditor.csproj
+++ b/OverloadLevelEditor/OverloadLevelEditor.csproj
@@ -257,6 +257,9 @@
     <Compile Include="..\Editor\Common\ImportOBJ.cs">
       <Link>Utility\ImportOBJ.cs</Link>
     </Compile>
+    <Compile Include="..\Editor\Common\ObjFile.cs">
+      <Link>Utility\ObjFile.cs</Link>
+    </Compile>
     <Compile Include="..\Editor\Common\UnityStub.cs">
       <Link>Utility\UnityStub.cs</Link>
     </Compile>

--- a/OverloadLevelEditor/Popups/DecalList.cs
+++ b/OverloadLevelEditor/Popups/DecalList.cs
@@ -412,7 +412,9 @@ namespace OverloadLevelEditor
 					return;
 				}
 
-				m_active_dmesh = new DMesh(replace ? m_active_dmesh.name : "");
+				string name = m_active_dmesh.name;
+				if (!replace)
+					m_active_dmesh = new DMesh("");
 
 				bool saved = ImportOBJToDecal(od.FileName);
 				if (!saved) {
@@ -421,9 +423,12 @@ namespace OverloadLevelEditor
 				}
 
 				if (replace) {
-					m_dmesh[m_cur_dmesh] = m_active_dmesh;
+					m_active_dmesh.name = name;
+					SaveDecalMesh(m_active_dmesh);
+					editor.RefreshAllGMeshes();
+					editor.Refresh();
 				} else { 
-					string name = InputBox.GetInput("Import Decal Mesh", "Enter a name for this decal (must be valid filename)", "");
+					name = InputBox.GetInput("Import Decal Mesh", "Enter a name for this decal (must be valid filename)", "");
 					if (name == null) {
 						listbox.SetSelected(old_active_dmesh_index, true);
 						return;


### PR DESCRIPTION
Add Import OBJ to DMeshEditor,
support multiple textures per Obj group with a different Obj loader,
support triangulation for quads, support more texture image file types,
fix adding new textures, better integrate replace import in level editor.