### PR TITLE
Fix display of textures in decal list

### DIFF
--- a/Editor/DMeshEditor/DMeshEditor/DMesh/DMeshEditor.cs
+++ b/Editor/DMeshEditor/DMeshEditor/DMesh/DMeshEditor.cs
@@ -69,12 +69,12 @@ namespace OverloadLevelEditor
 
 		public List<int> m_tex_gl_id;
 		
-		public void UpdateGLTextures(TextureManager tm)
+		public void UpdateGLTextures(TextureManager tm, TextureManager backup_tm = null)
 		{
 			for (int i = 0; i < tex_name.Count; i++) {
 				m_tex_gl_id[i] = tm.FindTextureIDByName(tex_name[i]);
-				if (m_tex_gl_id[i] == -1) {
-					m_tex_gl_id[i] = tm.FindTextureIDByName("_default");
+				if (m_tex_gl_id[i] == -1 && backup_tm != null) {
+					m_tex_gl_id[i] = backup_tm.FindTextureIDByName(tex_name[i]);
 				}
 			}
 		}

--- a/OverloadLevelEditor/Popups/DecalList.cs
+++ b/OverloadLevelEditor/Popups/DecalList.cs
@@ -546,7 +546,7 @@ namespace OverloadLevelEditor
             {
 				return;
             }
-			m_active_dmesh.UpdateGLTextures(tex_manager);
+			m_active_dmesh.UpdateGLTextures(tex_manager, editor.tm_level);
 			BuildDecalMesh(m_active_dmesh);
 			m_selected_face = -1;
 			BuildDecalSelected(m_active_dmesh, m_selected_face);

--- a/OverloadLevelEditor/Popups/DecalListUtility.cs
+++ b/OverloadLevelEditor/Popups/DecalListUtility.cs
@@ -58,7 +58,7 @@ namespace OverloadLevelEditor
 				// Load the decal into memory
 				m_active_dmesh = new DMesh(mesh_name);
 				LoadDecalMesh(m_active_dmesh, file);
-				m_active_dmesh.UpdateGLTextures(tex_manager);
+				m_active_dmesh.UpdateGLTextures(tex_manager, editor.tm_level);
 				m_dmesh.Add(m_active_dmesh);
 			}
 
@@ -145,7 +145,7 @@ namespace OverloadLevelEditor
 			GL.PushMatrix();
 			GL.DeleteLists(GL_DECAL, 1);
 			GL.NewList(GL_DECAL, ListMode.Compile);
-			int tex_id = -1;
+			int tex_id = -2; // start different from missing texture value -1
 			
 			{
 				GL.Begin(PrimitiveType.Triangles);
@@ -157,9 +157,10 @@ namespace OverloadLevelEditor
 						continue;
 					}
 
-					if (tex_id != dm.m_tex_gl_id[dm.triangle[i].tex_index]) {
+					int tri_tex_id = dm.triangle[i].tex_index == -1 ? -1 : dm.m_tex_gl_id[dm.triangle[i].tex_index];
+					if (tex_id != tri_tex_id) {
 						GL.End();
-						tex_id = dm.m_tex_gl_id[dm.triangle[i].tex_index];
+						tex_id = tri_tex_id;
 						GL.BindTexture(TextureTarget.Texture2D, tex_id);
 						GL.Begin(PrimitiveType.Triangles);
 					}


### PR DESCRIPTION
The decal list preview didn't display level textures and could show
a previous texture when a texture was missing.