### PR TITLE
Show current entity coordinates in Entity Coords input box

### DIFF
--- a/OverloadLevelEditor/Panes/EditorEntitiesEditPane.cs
+++ b/OverloadLevelEditor/Panes/EditorEntitiesEditPane.cs
@@ -206,8 +206,10 @@ namespace OverloadLevelEditor
 		{
 			var editor = ActiveDocument;
 			var level = ActiveLevel;
+			var oldPos = level.GetSelectedEntity().position;
 
-			string coords_text = InputBox.GetInput("Entity Coords", "Enter new coodtinates for this enity", "");
+			string coords_text = InputBox.GetInput("Entity Coords", "Enter new coordinates for this entity",
+				$"{oldPos.X},{oldPos.Y},{oldPos.Z}");
 			if (coords_text == null) {
 				return;
 			}


### PR DESCRIPTION
It's a pain to use the "Enter Position Coords" button since OLE currently doesn't show coordinates for anything to use as a frame of reference. Maybe we should do that, but I figured for now I can set the initial value of the input box to the entity's current position - that at least gives you an idea.