### PR TITLE
Fix minimized UV editor saved position bug

### DIFF
--- a/OverloadLevelEditor/Main/EditorOptions.cs
+++ b/OverloadLevelEditor/Main/EditorOptions.cs
@@ -471,7 +471,7 @@ namespace OverloadLevelEditor
 			UserPrefs.SetPoint("texture_set_list_loc", m_texture_set_list_loc);
 			UserPrefs.SetPoint("texture_set_list_sz", (Point)texture_set_list.Size);
 			UserPrefs.SetPoint("uv_editor_loc", m_uv_editor_loc);
-			UserPrefs.SetPoint("uv_editor_sz", (Point)uv_editor.Size);
+			UserPrefs.SetPoint("uv_editor_sz", (Point)uv_editor.RestoreBounds.Size);
 
 			UserPrefs.SetInt("mm_edit_type", (int)m_mm_edit_type);
 			UserPrefs.SetInt("mm_op_mode", (int)m_mm_op_mode);

--- a/OverloadLevelEditor/Popups/UVEditor.cs
+++ b/OverloadLevelEditor/Popups/UVEditor.cs
@@ -308,7 +308,7 @@ namespace OverloadLevelEditor
 
 		private void UVEditor_LocationChanged(object sender, EventArgs e)
 		{
-			if (Visible)
+			if (Visible && WindowState == FormWindowState.Normal)
 			{
 				editor.m_uv_editor_loc = this.Location;
 			}


### PR DESCRIPTION
Found an issue after my earlier pull request (#30) where the UV editor location and size would get updated, and written to preferences, even when the editor was minimized. This caused it to be unfindable after the editor was relaunched. Recoverable using the "restore default layout" action but still not great, so fixing this hopefully before most people need to experience it :)