### PR TITLE
Fix inverted UVs on the default segment

### DIFF
--- a/Assets/Editor/LevelConvert/Side.cs
+++ b/Assets/Editor/LevelConvert/Side.cs
@@ -48,10 +48,10 @@ namespace OverloadLevelEditor
 		public bool marked;
 		public int chunk_plane_order;       //if -1, this isn't a splitting plane.  Else it determines priority.
 
-		Vector2[] uv_default = { new Vector2(0f, 0f),
-										 new Vector2(0f, 1f),
+		Vector2[] uv_default = { new Vector2(1f, 0f),
 										 new Vector2(1f, 1f),
-										 new Vector2(1f, 0f)
+										 new Vector2(0f, 1f),
+										 new Vector2(0f, 0f)
 									  };
 
 		public Side(Segment seg, int n)


### PR DESCRIPTION
I inverted the default UVs so that they apply properly to sides on the default segment.
As far as I can tell this is the only time default UVs are used; in every other case, it looks like different UVs are applied right after.