### PR TITLE
Custom reflection probe options

### DIFF
--- a/Assets/Editor/LevelConvert/Entity.cs
+++ b/Assets/Editor/LevelConvert/Entity.cs
@@ -245,6 +245,7 @@ namespace OverloadLevelEditor
 		SPHERE,
 		SPHERE_EXIT,
 		SPHERE_STAY,
+		REFLECTION_PROBE,
 		
 		NUM,
 	}

--- a/Assets/Editor/LevelConvert/Level.cs
+++ b/Assets/Editor/LevelConvert/Level.cs
@@ -144,6 +144,7 @@ namespace OverloadLevelEditor
 			public bool m_alien_lava = false;
 			public int m_custom_count = 0;
 			public CustomLevelInfoObjective m_objective = CustomLevelInfoObjective.NORMAL;
+			public bool m_include_default_reflection_probes = true;
 
 			public void Serialize(JObject root)
 			{
@@ -152,6 +153,7 @@ namespace OverloadLevelEditor
 				root["alien_lava"] = m_alien_lava;
 				root["custom_count"] = m_custom_count;
 				root["objective"] = m_objective.ToString();
+				root["reflection_probes"] = m_include_default_reflection_probes ? "Default" : "None";
 			}
 
 			public void Deserialize(JObject root)
@@ -161,6 +163,7 @@ namespace OverloadLevelEditor
 				this.m_alien_lava = root["alien_lava"].GetBool(false);
 				this.m_custom_count = root["custom_count"].GetInt(0);
 				this.m_objective = (CustomLevelInfoObjective)Enum.Parse(typeof(CustomLevelInfoObjective), root["objective"].GetString("NORMAL"));
+				this.m_include_default_reflection_probes = root["reflection_probes"].GetString("Default") == "Default";
 			}
 		}
 

--- a/Assets/Editor/LevelConvert/OverloadLevelConvertEntity.cs
+++ b/Assets/Editor/LevelConvert/OverloadLevelConvertEntity.cs
@@ -174,6 +174,11 @@ public partial class OverloadLevelConverter
 					mp_camera_points.Add(new LevelData.SpawnPoint(entity_src.position.ToUnity(), entity_src.rotation.ExtractRotation().ToUnity(), 0));
 					continue;
 				}
+				if(entity_src.Type == OverloadLevelEditor.EntityType.TRIGGER && entity_src.SubType == (int)OverloadLevelEditor.TriggerSubType.REFLECTION_PROBE)
+				{
+					// reflection probe -- handled separately
+					continue;
+				}
 
 				// Resolve the prefab for the entity
 				Dictionary<int, IGameObjectBroker> cache_subtype_map;

--- a/OverloadLevelEditor/Export/UnityTypes.cs
+++ b/OverloadLevelEditor/Export/UnityTypes.cs
@@ -71,17 +71,19 @@ namespace UnityEngine
 	{
 		public enum ReflectionProbeMode
 		{
-			Baked
+			Baked = 0,
+			Realtime = 1,
 		}
 
 		public enum ReflectionProbeRefreshMode
 		{
-			ViaScripting
+			OnAwake = 0,
+			ViaScripting = 2
 		}
 
 		public enum ReflectionProbeClearFlags
 		{
-			SolidColor
+			SolidColor = 2
 		}
 	}
 

--- a/OverloadLevelEditor/Main/GLViewDraw.cs
+++ b/OverloadLevelEditor/Main/GLViewDraw.cs
@@ -649,7 +649,15 @@ namespace OverloadLevelEditor
 								// Draw the trigger links if selected
 								CreateLinkDiamonds(e);
 
-								if (e.SubType < (int)TriggerSubType.SPHERE) {
+								if(e.SubType == (int)TriggerSubType.REFLECTION_PROBE)
+								{
+									GL.PushMatrix();
+									// Reflection probes are always axis-aligned.
+									var unrotate = Matrix4.Invert(e.rotation);
+									GL.MultMatrix(ref unrotate);
+									CreateLineBox(((Overload.EntityPropsTrigger)e.entity_props).size * 0.5f);
+									GL.PopMatrix();
+								} else if (e.SubType < (int)TriggerSubType.SPHERE) {
 									CreateLineBox(((Overload.EntityPropsTrigger)e.entity_props).size * 0.5f);
 								} else {
 									CreateLineSphere(((Overload.EntityPropsTrigger)e.entity_props).size.X);

--- a/OverloadLevelEditor/Panes/EditorLevelCustomInfoPane.Designer.cs
+++ b/OverloadLevelEditor/Panes/EditorLevelCustomInfoPane.Designer.cs
@@ -40,147 +40,160 @@ namespace OverloadLevelEditor
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.label3 = new System.Windows.Forms.Label();
-			this.label4 = new System.Windows.Forms.Label();
-			this.textBoxObjectiveCount = new System.Windows.Forms.TextBox();
-			this.comboBoxObjective = new System.Windows.Forms.ComboBox();
-			this.label2 = new System.Windows.Forms.Label();
-			this.checkBoxAlienLava = new System.Windows.Forms.CheckBox();
-			this.checkBoxNoExplosionsOnExit = new System.Windows.Forms.CheckBox();
-			this.label1 = new System.Windows.Forms.Label();
-			this.textBoxExitMusicStartTime = new System.Windows.Forms.TextBox();
-			this.SuspendLayout();
-			// 
-			// label3
-			// 
-			this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label3.Location = new System.Drawing.Point(1, 85);
-			this.label3.Margin = new System.Windows.Forms.Padding(1);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(142, 18);
-			this.label3.TabIndex = 16;
-			this.label3.Text = "OBJECTIVE TYPE";
-			this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label4
-			// 
-			this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label4.Location = new System.Drawing.Point(-2, 43);
-			this.label4.Margin = new System.Windows.Forms.Padding(1);
-			this.label4.Name = "label4";
-			this.label4.Size = new System.Drawing.Size(145, 18);
-			this.label4.TabIndex = 15;
-			this.label4.Text = "OBJECTIVE COUNT";
-			this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// textBoxObjectiveCount
-			// 
-			this.textBoxObjectiveCount.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.textBoxObjectiveCount.Location = new System.Drawing.Point(86, 63);
-			this.textBoxObjectiveCount.Margin = new System.Windows.Forms.Padding(1);
-			this.textBoxObjectiveCount.Name = "textBoxObjectiveCount";
-			this.textBoxObjectiveCount.Size = new System.Drawing.Size(57, 20);
-			this.textBoxObjectiveCount.TabIndex = 2;
-			this.textBoxObjectiveCount.Leave += new System.EventHandler(this.textBoxObjectiveCount_Leave);
-			// 
-			// comboBoxObjective
-			// 
-			this.comboBoxObjective.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.comboBoxObjective.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.comboBoxObjective.FormattingEnabled = true;
-			this.comboBoxObjective.Location = new System.Drawing.Point(1, 106);
-			this.comboBoxObjective.Margin = new System.Windows.Forms.Padding(1);
-			this.comboBoxObjective.Name = "comboBoxObjective";
-			this.comboBoxObjective.Size = new System.Drawing.Size(142, 21);
-			this.comboBoxObjective.TabIndex = 1;
-			this.comboBoxObjective.SelectedIndexChanged += new System.EventHandler(this.comboBoxObjective_SelectedIndexChanged);
-			// 
-			// label2
-			// 
-			this.label2.AutoSize = true;
-			this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label2.Location = new System.Drawing.Point(21, 25);
-			this.label2.Margin = new System.Windows.Forms.Padding(1);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(53, 13);
-			this.label2.TabIndex = 11;
-			this.label2.Text = "[seconds]";
-			// 
-			// checkBoxAlienLava
-			// 
-			this.checkBoxAlienLava.AutoSize = true;
-			this.checkBoxAlienLava.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.checkBoxAlienLava.Location = new System.Drawing.Point(1, 151);
-			this.checkBoxAlienLava.Margin = new System.Windows.Forms.Padding(1);
-			this.checkBoxAlienLava.Name = "checkBoxAlienLava";
-			this.checkBoxAlienLava.Size = new System.Drawing.Size(142, 17);
-			this.checkBoxAlienLava.TabIndex = 4;
-			this.checkBoxAlienLava.Text = "Alien Level (affects lava)";
-			this.checkBoxAlienLava.UseVisualStyleBackColor = true;
-			this.checkBoxAlienLava.CheckedChanged += new System.EventHandler(this.checkBoxAlienLava_CheckedChanged);
-			// 
-			// checkBoxNoExplosionsOnExit
-			// 
-			this.checkBoxNoExplosionsOnExit.AutoSize = true;
-			this.checkBoxNoExplosionsOnExit.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.checkBoxNoExplosionsOnExit.Location = new System.Drawing.Point(1, 130);
-			this.checkBoxNoExplosionsOnExit.Margin = new System.Windows.Forms.Padding(1);
-			this.checkBoxNoExplosionsOnExit.Name = "checkBoxNoExplosionsOnExit";
-			this.checkBoxNoExplosionsOnExit.Size = new System.Drawing.Size(130, 17);
-			this.checkBoxNoExplosionsOnExit.TabIndex = 3;
-			this.checkBoxNoExplosionsOnExit.Text = "No Explosions On Exit";
-			this.checkBoxNoExplosionsOnExit.UseVisualStyleBackColor = true;
-			this.checkBoxNoExplosionsOnExit.CheckedChanged += new System.EventHandler(this.checkBoxNoExplosionsOnExit_CheckedChanged);
-			// 
-			// label1
-			// 
-			this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label1.Location = new System.Drawing.Point(-2, 1);
-			this.label1.Margin = new System.Windows.Forms.Padding(1);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(145, 18);
-			this.label1.TabIndex = 8;
-			this.label1.Text = "EXIT MUSIC OFFSET";
-			this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// textBoxExitMusicStartTime
-			// 
-			this.textBoxExitMusicStartTime.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.textBoxExitMusicStartTime.Location = new System.Drawing.Point(86, 20);
-			this.textBoxExitMusicStartTime.Margin = new System.Windows.Forms.Padding(1);
-			this.textBoxExitMusicStartTime.Name = "textBoxExitMusicStartTime";
-			this.textBoxExitMusicStartTime.Size = new System.Drawing.Size(57, 20);
-			this.textBoxExitMusicStartTime.TabIndex = 0;
-			this.textBoxExitMusicStartTime.Leave += new System.EventHandler(this.textBoxExitMusicStartTime_Leave);
-			// 
-			// EditorLevelCustomInfoPane
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(148, 168);
-			this.Controls.Add(this.label3);
-			this.Controls.Add(this.label4);
-			this.Controls.Add(this.textBoxObjectiveCount);
-			this.Controls.Add(this.comboBoxObjective);
-			this.Controls.Add(this.label2);
-			this.Controls.Add(this.checkBoxAlienLava);
-			this.Controls.Add(this.checkBoxNoExplosionsOnExit);
-			this.Controls.Add(this.label1);
-			this.Controls.Add(this.textBoxExitMusicStartTime);
-			this.DockAreas = ((WeifenLuo.WinFormsUI.Docking.DockAreas)(((((WeifenLuo.WinFormsUI.Docking.DockAreas.Float | WeifenLuo.WinFormsUI.Docking.DockAreas.DockLeft) 
+            this.label3 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.textBoxObjectiveCount = new System.Windows.Forms.TextBox();
+            this.comboBoxObjective = new System.Windows.Forms.ComboBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.checkBoxAlienLava = new System.Windows.Forms.CheckBox();
+            this.checkBoxNoExplosionsOnExit = new System.Windows.Forms.CheckBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.textBoxExitMusicStartTime = new System.Windows.Forms.TextBox();
+            this.checkBoxIncludeDefaultReflectionProbes = new System.Windows.Forms.CheckBox();
+            this.SuspendLayout();
+            // 
+            // label3
+            // 
+            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label3.Location = new System.Drawing.Point(1, 85);
+            this.label3.Margin = new System.Windows.Forms.Padding(1);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(142, 18);
+            this.label3.TabIndex = 16;
+            this.label3.Text = "OBJECTIVE TYPE";
+            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label4
+            // 
+            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label4.Location = new System.Drawing.Point(-2, 43);
+            this.label4.Margin = new System.Windows.Forms.Padding(1);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(145, 18);
+            this.label4.TabIndex = 15;
+            this.label4.Text = "OBJECTIVE COUNT";
+            this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // textBoxObjectiveCount
+            // 
+            this.textBoxObjectiveCount.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.textBoxObjectiveCount.Location = new System.Drawing.Point(86, 63);
+            this.textBoxObjectiveCount.Margin = new System.Windows.Forms.Padding(1);
+            this.textBoxObjectiveCount.Name = "textBoxObjectiveCount";
+            this.textBoxObjectiveCount.Size = new System.Drawing.Size(57, 20);
+            this.textBoxObjectiveCount.TabIndex = 2;
+            this.textBoxObjectiveCount.Leave += new System.EventHandler(this.textBoxObjectiveCount_Leave);
+            // 
+            // comboBoxObjective
+            // 
+            this.comboBoxObjective.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxObjective.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.comboBoxObjective.FormattingEnabled = true;
+            this.comboBoxObjective.Location = new System.Drawing.Point(1, 106);
+            this.comboBoxObjective.Margin = new System.Windows.Forms.Padding(1);
+            this.comboBoxObjective.Name = "comboBoxObjective";
+            this.comboBoxObjective.Size = new System.Drawing.Size(142, 21);
+            this.comboBoxObjective.TabIndex = 1;
+            this.comboBoxObjective.SelectedIndexChanged += new System.EventHandler(this.comboBoxObjective_SelectedIndexChanged);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(21, 25);
+            this.label2.Margin = new System.Windows.Forms.Padding(1);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(53, 13);
+            this.label2.TabIndex = 11;
+            this.label2.Text = "[seconds]";
+            // 
+            // checkBoxAlienLava
+            // 
+            this.checkBoxAlienLava.AutoSize = true;
+            this.checkBoxAlienLava.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.checkBoxAlienLava.Location = new System.Drawing.Point(1, 151);
+            this.checkBoxAlienLava.Margin = new System.Windows.Forms.Padding(1);
+            this.checkBoxAlienLava.Name = "checkBoxAlienLava";
+            this.checkBoxAlienLava.Size = new System.Drawing.Size(142, 17);
+            this.checkBoxAlienLava.TabIndex = 4;
+            this.checkBoxAlienLava.Text = "Alien Level (affects lava)";
+            this.checkBoxAlienLava.UseVisualStyleBackColor = true;
+            this.checkBoxAlienLava.CheckedChanged += new System.EventHandler(this.checkBoxAlienLava_CheckedChanged);
+            // 
+            // checkBoxNoExplosionsOnExit
+            // 
+            this.checkBoxNoExplosionsOnExit.AutoSize = true;
+            this.checkBoxNoExplosionsOnExit.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.checkBoxNoExplosionsOnExit.Location = new System.Drawing.Point(1, 130);
+            this.checkBoxNoExplosionsOnExit.Margin = new System.Windows.Forms.Padding(1);
+            this.checkBoxNoExplosionsOnExit.Name = "checkBoxNoExplosionsOnExit";
+            this.checkBoxNoExplosionsOnExit.Size = new System.Drawing.Size(130, 17);
+            this.checkBoxNoExplosionsOnExit.TabIndex = 3;
+            this.checkBoxNoExplosionsOnExit.Text = "No Explosions On Exit";
+            this.checkBoxNoExplosionsOnExit.UseVisualStyleBackColor = true;
+            this.checkBoxNoExplosionsOnExit.CheckedChanged += new System.EventHandler(this.checkBoxNoExplosionsOnExit_CheckedChanged);
+            // 
+            // label1
+            // 
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(-2, 1);
+            this.label1.Margin = new System.Windows.Forms.Padding(1);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(145, 18);
+            this.label1.TabIndex = 8;
+            this.label1.Text = "EXIT MUSIC OFFSET";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // textBoxExitMusicStartTime
+            // 
+            this.textBoxExitMusicStartTime.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.textBoxExitMusicStartTime.Location = new System.Drawing.Point(86, 20);
+            this.textBoxExitMusicStartTime.Margin = new System.Windows.Forms.Padding(1);
+            this.textBoxExitMusicStartTime.Name = "textBoxExitMusicStartTime";
+            this.textBoxExitMusicStartTime.Size = new System.Drawing.Size(57, 20);
+            this.textBoxExitMusicStartTime.TabIndex = 0;
+            this.textBoxExitMusicStartTime.Leave += new System.EventHandler(this.textBoxExitMusicStartTime_Leave);
+            // 
+            // checkBoxIncludeDefaultReflectionProbes
+            // 
+            this.checkBoxIncludeDefaultReflectionProbes.AutoSize = true;
+            this.checkBoxIncludeDefaultReflectionProbes.Location = new System.Drawing.Point(1, 172);
+            this.checkBoxIncludeDefaultReflectionProbes.Name = "checkBoxIncludeDefaultReflectionProbes";
+            this.checkBoxIncludeDefaultReflectionProbes.Size = new System.Drawing.Size(147, 17);
+            this.checkBoxIncludeDefaultReflectionProbes.TabIndex = 17;
+            this.checkBoxIncludeDefaultReflectionProbes.Text = "Default Reflection Probes";
+            this.checkBoxIncludeDefaultReflectionProbes.UseVisualStyleBackColor = true;
+            this.checkBoxIncludeDefaultReflectionProbes.CheckedChanged += new System.EventHandler(this.checkBoxIncludeDefaultReflectionProbes_CheckedChanged);
+            // 
+            // EditorLevelCustomInfoPane
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(148, 194);
+            this.Controls.Add(this.checkBoxIncludeDefaultReflectionProbes);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.textBoxObjectiveCount);
+            this.Controls.Add(this.comboBoxObjective);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.checkBoxAlienLava);
+            this.Controls.Add(this.checkBoxNoExplosionsOnExit);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.textBoxExitMusicStartTime);
+            this.DockAreas = ((WeifenLuo.WinFormsUI.Docking.DockAreas)(((((WeifenLuo.WinFormsUI.Docking.DockAreas.Float | WeifenLuo.WinFormsUI.Docking.DockAreas.DockLeft) 
             | WeifenLuo.WinFormsUI.Docking.DockAreas.DockRight) 
             | WeifenLuo.WinFormsUI.Docking.DockAreas.DockTop) 
             | WeifenLuo.WinFormsUI.Docking.DockAreas.DockBottom)));
-			this.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
-			this.HideOnClose = true;
-			this.MinimumSize = new System.Drawing.Size(143, 39);
-			this.Name = "EditorLevelCustomInfoPane";
-			this.Text = "CUSTOM INFO";
-			this.Load += new System.EventHandler(this.EditorLevelCustomInfoPane_Load);
-			this.VisibleChanged += new System.EventHandler(this.EditorLevelCustomInfoPane_VisibleChanged);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
+            this.HideOnClose = true;
+            this.MinimumSize = new System.Drawing.Size(143, 39);
+            this.Name = "EditorLevelCustomInfoPane";
+            this.Text = "CUSTOM INFO";
+            this.Load += new System.EventHandler(this.EditorLevelCustomInfoPane_Load);
+            this.VisibleChanged += new System.EventHandler(this.EditorLevelCustomInfoPane_VisibleChanged);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -195,5 +208,6 @@ namespace OverloadLevelEditor
 		private System.Windows.Forms.Label label4;
 		private System.Windows.Forms.TextBox textBoxObjectiveCount;
 		private System.Windows.Forms.Label label3;
-	}
+        private System.Windows.Forms.CheckBox checkBoxIncludeDefaultReflectionProbes;
+    }
 }

--- a/OverloadLevelEditor/Panes/EditorLevelCustomInfoPane.cs
+++ b/OverloadLevelEditor/Panes/EditorLevelCustomInfoPane.cs
@@ -51,6 +51,7 @@ namespace OverloadLevelEditor
 			this.checkBoxAlienLava.Checked = level.custom_level_info.m_alien_lava;
 			this.checkBoxNoExplosionsOnExit.Checked = level.custom_level_info.m_exit_no_explosions;
 			this.comboBoxObjective.SelectedIndex = (int)level.custom_level_info.m_objective;
+			this.checkBoxIncludeDefaultReflectionProbes.Checked = level.custom_level_info.m_include_default_reflection_probes;
 		}
 
 		public void SetDataString(string s)
@@ -152,6 +153,18 @@ namespace OverloadLevelEditor
 			textBoxExitMusicStartTime_Leave(sender, e);
 			textBoxObjectiveCount_Leave(sender, e);
 
+		}
+
+		private void checkBoxIncludeDefaultReflectionProbes_CheckedChanged(object sender, EventArgs e)
+		{
+			if (ActiveLevel == null) return;
+
+			var newVal = checkBoxIncludeDefaultReflectionProbes.Checked;
+			if(newVal != ActiveLevel.custom_level_info.m_include_default_reflection_probes)
+			{
+				ActiveLevel.custom_level_info.m_include_default_reflection_probes = newVal;
+				ActiveLevel.dirty = true;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This includes the following changes:
* Trigger entity subtype for placing reflection probes directly instead of through LevelPost
* Checkbox in level custom info to include or exclude default chunk-based reflection probes on export
* Exported reflection probes are always forced on

In the .overload file I saved the default reflection probes option as a string saying either "Default" or "None" because I wasn't sure whether or not to always force on reflection probes or leave it as an option like LevelPost does. But I think it could be simplified since the default refreshing behaviour only causes problems.

As far as I can tell OLE actually handles file format changes pretty gracefully. Other versions of the editor can still load levels with these changes, but will interpret Reflection Probe triggers as Box triggers.