### PR TITLE
Customize door activation range

### DIFF
--- a/Assets/Editor/LevelConvert/EntityPropsEditor.cs
+++ b/Assets/Editor/LevelConvert/EntityPropsEditor.cs
@@ -86,6 +86,10 @@ namespace OverloadLevelEditor
 			root["door_lock"] = ((int)entity_props.m_door_lock).ToString();
 			root["robot_access"] = entity_props.m_robot_access.ToString();
 			root["no_chunk"] = entity_props.m_no_chunk.ToString();
+			if (entity_props.m_trigger_depth.HasValue)
+			{
+				root["trigger_depth"] = entity_props.m_trigger_depth.ToString();
+			}
 		}
 
 		public void Deserialize( EntityPropsDoor entity_props, JObject root )
@@ -93,6 +97,10 @@ namespace OverloadLevelEditor
 			entity_props.m_door_lock = root["door_lock"].GetEnum<DoorLock>(DoorLock.NONE);
 			entity_props.m_robot_access = root["robot_access"].GetBool();
 			entity_props.m_no_chunk = root["no_chunk"].GetBool();
+			if (root["trigger_depth"].IsValid())
+			{
+				entity_props.m_trigger_depth = root["trigger_depth"].GetFloat();
+			}
 		}
 
 		// ITEM

--- a/Assets/Editor/LevelConvert/OverloadLevelConvertEntity.cs
+++ b/Assets/Editor/LevelConvert/OverloadLevelConvertEntity.cs
@@ -304,6 +304,11 @@ public partial class OverloadLevelConverter
 								portal_index = -1;
 							}
 
+							if (p_door.TriggerDepth.HasValue)
+                            {
+								entity_instance.GetComponentInChildren("DoorAnimating").SetProperty<float>("m_player_trigger_depth", p_door.TriggerDepth.Value);
+							}
+
 							e_door.SetProperty("LockType", p_door.m_door_lock);
 							e_door.SetProperty("Portal", portal_index);
 							e_door.SetProperty("NoChunk", p_door.m_no_chunk);

--- a/Assets/Scripts/Game/EntityProps.cs
+++ b/Assets/Scripts/Game/EntityProps.cs
@@ -302,7 +302,18 @@ namespace Overload
 			set { m_no_chunk = value; }
 		}
 
+		/// <summary>
+		/// Depth of the door's auto-open trigger, in units. Includes both sides of the door.
+		/// Set to null or a negative value to use the door's default value.
+		/// </summary>
+		public float? TriggerDepth
+        {
+			get { return m_trigger_depth; }
+			set { m_trigger_depth = (value == null || value < 0) ? null : value; }
+        }
+
 		public DoorLock m_door_lock = DoorLock.NONE;
+		public float? m_trigger_depth;
 		public bool m_robot_access = false;
 		public bool m_no_chunk = false;			// Not part of a chunk for activation purposes
 


### PR DESCRIPTION
Doors automatically open when the player gets near. This change enables customizing how close they need to get before the door opens, using a new property called TriggerDepth.
This is useful because the default trigger depth of 12 units (6 on each side of the door) can sometimes be difficult to design around. A shallower trigger allows for smaller doorways without having to worry about the player accidentally opening doors.
If the property is cleared, or not set to begin with, the default size will be used instead.