### PR TITLE
Add ability to customize prop and matcen HP

### DIFF
--- a/Assets/Editor/LevelConvert/EntityPropsEditor.cs
+++ b/Assets/Editor/LevelConvert/EntityPropsEditor.cs
@@ -118,6 +118,10 @@ namespace OverloadLevelEditor
 			root["invulnerable"] = entity_props.invulnerable.ToString();
 			root["m_no_chunk"] = entity_props.m_no_chunk.ToString();
 			root["index"] = entity_props.index.ToString();
+			if (entity_props.m_hp.HasValue)
+			{
+				root["m_hp"] = entity_props.m_hp.ToString();
+			}
 		}
 
 		public void Deserialize( EntityPropsProp entity_props, JObject root )
@@ -125,6 +129,10 @@ namespace OverloadLevelEditor
 			entity_props.invulnerable = root["invulnerable"].GetBool();
 			entity_props.m_no_chunk = root["m_no_chunk"].GetBool();
 			entity_props.index = root["index"].GetInt();
+			if (root["m_hp"].IsValid())
+			{
+				entity_props.m_hp = root["m_hp"].GetFloat();
+			}
 		}
 
 		// SCRIPT
@@ -223,6 +231,10 @@ namespace OverloadLevelEditor
 			root["m_max_alive"] = entity_props.m_max_alive.ToString();
 			root["m_spawn_wait"] = entity_props.m_spawn_wait.ToString();
 			root["ed_invulnerable"] = entity_props.ed_invulnerable.ToString();
+			if (entity_props.m_hp.HasValue)
+			{
+				root["m_hp"] = entity_props.m_hp.ToString();
+			}
 		}
 
 		public void Deserialize(EntityPropsSpecial entity_props, JObject root )
@@ -235,6 +247,10 @@ namespace OverloadLevelEditor
 			entity_props.m_max_alive = root["m_max_alive"].GetInt();
 			entity_props.m_spawn_wait = root["m_spawn_wait"].GetEnum<MatcenSpawnWait>(MatcenSpawnWait.MEDIUM);
 			entity_props.ed_invulnerable = root["ed_invulnerable"].GetBool();
+			if (root["m_hp"].IsValid())
+			{
+				entity_props.m_hp = root["m_hp"].GetFloat();
+			}
 		}
 	}
 

--- a/Assets/Editor/LevelConvert/OverloadLevelConvertEntity.cs
+++ b/Assets/Editor/LevelConvert/OverloadLevelConvertEntity.cs
@@ -389,7 +389,9 @@ public partial class OverloadLevelConverter
 							if(p_special.m_hp.HasValue)
                             {
 								e_special_destroyable.SetProperty("m_hp", p_special.m_hp);
-                            }
+								// Use this property to tell olmod that it shouldn't add extra HP to this matcen based on mission progress.
+								e_special_destroyable.SetProperty("m_special_index", 2);
+							}
 						} break;
 
 					case Overload.EntityPropsType.Trigger: {

--- a/Assets/Editor/LevelConvert/OverloadLevelConvertEntity.cs
+++ b/Assets/Editor/LevelConvert/OverloadLevelConvertEntity.cs
@@ -387,7 +387,7 @@ public partial class OverloadLevelConverter
 							e_special.SetProperty("m_matcen_spawn_wait", (float)p_special.m_spawn_wait);
 							e_special.SetProperty("m_invulnerable", (bool)p_special.ed_invulnerable);
 							if(p_special.m_hp.HasValue)
-                            {
+							{
 								e_special_destroyable.SetProperty("m_hp", p_special.m_hp);
 								// Use this property to tell olmod that it shouldn't add extra HP to this matcen based on mission progress.
 								e_special_destroyable.SetProperty("m_special_index", 2);

--- a/Assets/Editor/LevelConvert/OverloadLevelConvertEntity.cs
+++ b/Assets/Editor/LevelConvert/OverloadLevelConvertEntity.cs
@@ -346,11 +346,16 @@ public partial class OverloadLevelConverter
 
 					case Overload.EntityPropsType.Prop: {
 							var e_prop = entity_instance.GetComponentInChildren("PropBase");
+							var e_special_destroyable = entity_instance.GetComponentInChildren("Destroyable");
 							var p_prop = (Overload.EntityPropsProp)entity_props;
 
 							e_prop.SetProperty("m_invulnerable", p_prop.invulnerable);
 							e_prop.SetProperty("m_index", p_prop.index);
 							e_prop.SetProperty("NoChunk", p_prop.m_no_chunk);
+							if (p_prop.m_hp.HasValue)
+							{
+								e_special_destroyable.SetProperty("m_hp", p_prop.m_hp);
+							}
 						} break;
 
 					case Overload.EntityPropsType.Script: {
@@ -364,6 +369,7 @@ public partial class OverloadLevelConverter
 
 					case Overload.EntityPropsType.Special: {
 							var e_special = entity_instance.GetComponentInChildren("RobotMatcen");
+							var e_special_destroyable = entity_instance.GetComponentInChildren("Destroyable");
 							var p_special = (Overload.EntityPropsSpecial)entity_props;
 							float spawn_prob1 = (float)p_special.matcen_spawn_probability_1;
 							float spawn_prob2 = (float)p_special.matcen_spawn_probability_2;
@@ -380,6 +386,10 @@ public partial class OverloadLevelConverter
 							e_special.SetProperty("m_matcen_max_robots_alive", p_special.m_max_alive);
 							e_special.SetProperty("m_matcen_spawn_wait", (float)p_special.m_spawn_wait);
 							e_special.SetProperty("m_invulnerable", (bool)p_special.ed_invulnerable);
+							if(p_special.m_hp.HasValue)
+                            {
+								e_special_destroyable.SetProperty("m_hp", p_special.m_hp);
+                            }
 						} break;
 
 					case Overload.EntityPropsType.Trigger: {

--- a/Assets/Scripts/Game/EntityProps.cs
+++ b/Assets/Scripts/Game/EntityProps.cs
@@ -375,10 +375,10 @@ namespace Overload
 		}
 
 		public float? Hp
-        {
+		{
 			get { return m_hp; }
 			set { m_hp = value; }
-        }
+		}
 
 		public bool m_no_chunk = false;
 		public bool invulnerable = false;
@@ -667,10 +667,10 @@ namespace Overload
 		}
 
 		public float? Hp
-        {
+		{
 			get { return m_hp; }
 			set { m_hp = value; }
-        }
+		}
 
 		public MatcenSpecialProperties special_props = MatcenSpecialProperties.NONE;
 		public int m_max_alive = 3;

--- a/Assets/Scripts/Game/EntityProps.cs
+++ b/Assets/Scripts/Game/EntityProps.cs
@@ -374,9 +374,16 @@ namespace Overload
 			set { m_no_chunk = value; }
 		}
 
+		public float? Hp
+        {
+			get { return m_hp; }
+			set { m_hp = value; }
+        }
+
 		public bool m_no_chunk = false;
 		public bool invulnerable = false;
 		public int index = 0;
+		public float? m_hp = null;
 	}
 
 	[Serializable]
@@ -659,6 +666,12 @@ namespace Overload
 			set { ed_invulnerable = value; }
 		}
 
+		public float? Hp
+        {
+			get { return m_hp; }
+			set { m_hp = value; }
+        }
+
 		public MatcenSpecialProperties special_props = MatcenSpecialProperties.NONE;
 		public int m_max_alive = 3;
 		public MatcenSpawnWait m_spawn_wait = MatcenSpawnWait.MEDIUM;
@@ -667,6 +680,7 @@ namespace Overload
 		public EnemyType matcen_spawn_type_2 = EnemyType.RECOILA;
 		public float matcen_spawn_probability_2 = 0f;
 		public bool ed_invulnerable = false;
+		public float? m_hp = null;
 	}
 
 #if OVERLOAD_LEVEL_EDITOR


### PR DESCRIPTION
These changes add new HP properties to Prop and Special entities. Setting this property changes the starting HP of applicable objects, such as power cores, reactors, and matcens. The new properties are optional so they should be compatible with older levels.

There is a related pull request for olmod, [#235](https://github.com/overload-development-community/olmod/pull/235), which will recognize when matcen HP has been set from the editor and disable an effect which adds more HP. This is done so that what you put in the editor is what you get in-game.